### PR TITLE
Restricting messages that get sent to the IFRAME to the expected host

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,7 @@ function tryGetHost(url) {
 	url = url || '';
 
 	var host = url;
-	if(url.indexOf('//') === 0) {
-		host = url.substr(2);
-	} else if(url.indexOf('http://') === 0) {
+	if(url.indexOf('http://') === 0) {
 		host = url.substr(7);
 	} else if(url.indexOf('https://') ===0) {
 		host = url.substr(8);
@@ -82,7 +80,7 @@ module.exports = function(req) {
 		}
 		iframe.contentWindow.postMessage(
 			JSON.stringify(msg),
-			'*'
+			host
 		);
 	}
 

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,8 @@ describe('superagent-d2l-cors-proxy', function() {
 			undefined,
 			'',
 			'foo.html',
-			'/foo.ca'
+			'/foo.ca',
+			'//host.com'
 		].forEach(function(url) {
 			it('should fail with no protocol: ' + url, function() {
 				var host = corsProxy._tryGetHost(url);
@@ -47,7 +48,7 @@ describe('superagent-d2l-cors-proxy', function() {
 			});
 		});
 
-		['//', 'http://', 'https://'].forEach(function(protocol) {
+		['http://', 'https://'].forEach(function(protocol) {
 			[
 				'host.com',
 				'host.com/',


### PR DESCRIPTION
@dbatiste: I was able to limit messages, but could no longer support scheme-relative hosts.