### PR TITLE
Handle the proxied query as an Array

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 				var data = JSON.parse(evt.data);
 				var localUrl = makeUrlLocal(data.url);
 				superagent(data.method, localUrl)
-					.query(data.query)
+					.query(data.query && data.query.join('&'))
 					.timeout(data.timeout)
 					.send(data.data)
 					.set(data.header)


### PR DESCRIPTION
Modify the superagent call in `index.html` to ensure that a string is supplied to `query()`.  Follows the handling of the query Array from [superagent internals](https://github.com/visionmedia/superagent/blob/dab065cf44b3c3e2e0f61b71f0dce5f502f1d7cb/lib/client.js#L948).

Fixes #19.